### PR TITLE
feat: enable strict type checking. enable some more rules

### DIFF
--- a/eslint/fragments.js
+++ b/eslint/fragments.js
@@ -37,6 +37,16 @@ module.exports = {
 		'@typescript-eslint/explicit-module-boundary-types': ['error'],
 		'@typescript-eslint/promise-function-async': 'error',
 		'@typescript-eslint/require-await': 'off', // conflicts with 'promise-function-async'
+
+		/** Disable some annoyingly strict rules from the 'recommended-requiring-type-checking' pack */
+		'@typescript-eslint/no-unsafe-assignment': 0,
+		'@typescript-eslint/no-unsafe-member-access': 0,
+		'@typescript-eslint/no-unsafe-argument': 0,
+		'@typescript-eslint/no-unsafe-return': 0,
+		'@typescript-eslint/no-unsafe-call': 0,
+		'@typescript-eslint/restrict-template-expressions': 0,
+		'@typescript-eslint/restrict-plus-operands': 0,
+		/** End 'recommended-requiring-type-checking' overrides */
 	},
 
 	tsParser: {

--- a/eslint/fragments.js
+++ b/eslint/fragments.js
@@ -12,6 +12,7 @@ module.exports = {
 		'eslint:recommended',
 		'plugin:@typescript-eslint/eslint-recommended',
 		'plugin:@typescript-eslint/recommended',
+		'plugin:@typescript-eslint/recommended-requiring-type-checking',
 		'plugin:node/recommended',
 		'plugin:jest/recommended',
 		'prettier',
@@ -33,6 +34,9 @@ module.exports = {
 		'@typescript-eslint/interface-name-prefix': 'off',
 		'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_(.+)' }],
 		'@typescript-eslint/no-floating-promises': 'error',
+		'@typescript-eslint/explicit-module-boundary-types': ['error'],
+		'@typescript-eslint/promise-function-async': 'error',
+		'@typescript-eslint/require-await': 'off', // conflicts with 'promise-function-async'
 	},
 
 	tsParser: {


### PR DESCRIPTION
The updated list of new rules:

* @typescript-eslint/await-thenable
* @typescript-eslint/no-floating-promises
* @typescript-eslint/no-for-in-array
* @typescript-eslint/no-misused-promises
* @typescript-eslint/no-unnecessary-type-assertion
* @typescript-eslint/unbound-method
* 
* @typescript-eslint/explicit-module-boundary-types
* @typescript-eslint/promise-function-async

Info about each rule is at https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin#supported-rules

TSR produces ~30 non auto-fixable cases. Core 130 non auto-fixable cases. A large amount of these are needing to add return types to methods.