### PR TITLE
fix: use prerelease identifier

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -67,6 +67,8 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
           NEW_VERSION=$(node -p "require('./package.json').version")
           yarn publish --access=public --new-version=$NEW_VERSION --network-timeout 100000 --tag ${{ steps.do-publish.outputs.tag }}
+
+          echo "**Published:** $NEW_VERSION" >> $GITHUB_STEP_SUMMARY
         env:
           CI: true
   validate-dependencies:

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -21,11 +21,11 @@ jobs:
       - validate-dependencies
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
       - name: Check release is desired
@@ -78,9 +78,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
       - name: Prepare Environment
@@ -105,9 +105,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
       - name: Prepare Environment

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Bump version and build
         if: ${{ steps.do-publish.outputs.publish }}
         run: |
-          PRERELEASE_TAG=nightly-$(echo "${{ steps.prerelease-tag.outputs.tag }}")
+          PRERELEASE_TAG=nightly-${{ steps.prerelease-tag.outputs.tag }}
           yarn release --prerelease $PRERELEASE_TAG
         env:
           CI: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,5 +54,7 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
           NEW_VERSION=$(node -p "require('./package.json').version")
           yarn publish --access=public --new-version=$NEW_VERSION --network-timeout 100000 --tag "${{ steps.do-publish.outputs.publish }}"
+
+          echo "**Published:** $NEW_VERSION" >> $GITHUB_STEP_SUMMARY
         env:
           CI: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,11 +44,8 @@ jobs:
       - name: Bump version and build
         if: ${{ steps.do-publish.outputs.publish }}
         run: |
-          COMMIT_TIMESTAMP=$(git log -1 --pretty=format:%ct HEAD)
-          COMMIT_DATE=$(date -d @$COMMIT_TIMESTAMP +%Y%m%d-%H%M%S)
-          GIT_HASH=$(git rev-parse --short HEAD)
-          PRERELEASE_TAG=nightly-$(echo "${{ steps.prerelease-tag.outputs.tag }}" | sed -r 's/[^a-z0-9]+/-/gi')
-          yarn release --prerelease $PRERELEASE_TAG-$COMMIT_DATE-$GIT_HASH --skip.changelog --skip.tag --skip.commit
+          PRERELEASE_TAG=nightly-$(echo "${{ steps.prerelease-tag.outputs.tag }}")
+          yarn release --prerelease $PRERELEASE_TAG
         env:
           CI: true
       - name: Publish to NPM

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,11 +11,11 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
       - name: Check release is desired

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ Steps:
 - Update the prerelease workflow to change `yarn release --prerelease $PRERELEASE_TAG-$COMMIT_DATE-$GIT_HASH --skip.changelog --skip.tag --skip.commit` into `yarn release --prerelease $PRERELEASE_TAG`
 - Remove the unused `COMMIT_DATE`, `GIT_HASH` and `COMMIT_TIMESTAMP` definitions above
 - Change the variable `PRERELEASE_TAG=nightly-$(echo "${{ steps.prerelease-tag.outputs.tag }}" | sed -r 's/[^a-z0-9]+/-/gi')` to `PRERELEASE_TAG=nightly-${{ steps.prerelease-tag.outputs.tag }}`
+- Make sure there aren't any other usages of `standard-version` or the release script, if there are they will need updating.
+- Below any `yarn publish ....` lines, add `echo "**Published:** $NEW_VERSION" >> $GITHUB_STEP_SUMMARY` to log the publish in the github action workflow
+
+While you are here, try to update any `uses:` lines in the actions workflows, common ones that need updating:
+- `actions/checkout@v3`
+- `actions/setup-node@v3`
 
 #### v0.4 to v0.5
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ module.exports = {
 
 ### Upgrade
 
+#### v2.0 to v2.1
+
+This release introduces a simple replacement for `standard-version`
+
+Steps:
+
+- Remove the `standard-version` config block in your package.json
+- Remove the devDependency on `standard-version`
+- Update any scripts using `standard-version` to use `sofie-version`, if there are any parameters, they will likely all need removing.
+- Update the prerelease workflow to change `yarn release --prerelease $PRERELEASE_TAG-$COMMIT_DATE-$GIT_HASH --skip.changelog --skip.tag --skip.commit` into `yarn release --prerelease $PRERELEASE_TAG`
+- Remove the unused `COMMIT_DATE`, `GIT_HASH` and `COMMIT_TIMESTAMP` definitions above
+- Change the variable `PRERELEASE_TAG=nightly-$(echo "${{ steps.prerelease-tag.outputs.tag }}" | sed -r 's/[^a-z0-9]+/-/gi')` to `PRERELEASE_TAG=nightly-${{ steps.prerelease-tag.outputs.tag }}`
+
 #### v0.4 to v0.5
 
 This updates husky, and the config that goes with it.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 	"dependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.41.0",
 		"@typescript-eslint/parser": "^5.41.0",
+		"date-fns": "^2.29.3",
 		"eslint": "^8.26.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-jest": "^27.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,6 +412,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
 debug@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"


### PR DESCRIPTION
We usually invoke standard version with `--prerelease nightly-branch-name-20221012-150403-af628da`, so that we get a unique suffix.
This implements that in the new script. Prior to this, it would ignore the value to this and would end up with always producing prerelease `.0`, which limits publishing