### PR TITLE
docs(README): use correct name for tslib

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ yarn lint-staged
 **Ensure** the following development dependencies are present:
 
 - `@types\node` and `@types\jest` (if using)
-- Typescript 4 or above, e.g. `~4.0` with an up-to-date `ts-lib`
+- Typescript 4 or above, e.g. `~4.0` with an up-to-date `tslib`
 - `jest` and `ts-jest`, if using
 
 **Remove** any other linting configurations or linters. Also, `node-license-validator` is no longer required. Remove libraries that are re-exported by this project `husky`, `lint-staged`, `eslint` and `prettier`


### PR DESCRIPTION
ts-lib is some 6 year old package with no README, tslib is the correct package.