### PR TITLE
Change `engines` to allow for all new node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		}
 	],
 	"engines": {
-		"node": "^14.18 || ^16.14 || ^18.0"
+		"node": "^14.18 || ^16.14 || >=18"
 	},
 	"bin": {
 		"sofie-licensecheck": "./bin/checkLicenses.mjs",


### PR DESCRIPTION
This PR changes the allowed Node-versions in package.json file to allow all newer node-versions.

My reasoning for this is that I think that we should not hold back other libraries by disallowing the use of newer versions of Node.


This PR is similar to https://github.com/nrkno/sofie-timeline-state-resolver/pull/245