### PR TITLE
fix: add BlueOak-1.0.0 to allowed licenses

### DIFF
--- a/bin/checkLicenses.mjs
+++ b/bin/checkLicenses.mjs
@@ -42,7 +42,7 @@ const pkgInfo = readPackageUpSync()
 const projectNameAndVersion = `${pkgInfo.packageJson.name}@${pkgInfo.packageJson.version}`
 
 // TODO - Add option driven allowList selection with a list for GPL projects
-const allowListForMit = 'MIT;BSD;ISC;Apache-2.0;CC0;CC-BY-3.0;CC-BY-4.0;Unlicense;Artistic-2.0;Python-2.0'
+const allowListForMit = 'MIT;BSD;ISC;Apache-2.0;CC0;CC-BY-3.0;CC-BY-4.0;Unlicense;Artistic-2.0;Python-2.0;BlueOak-1.0.0'
 
 let excludePackages = projectNameAndVersion
 if (cli.flags.allowPackages) {


### PR DESCRIPTION
## What?
Add [BlueOak-1.0.0](https://github.com/isaacs/jackspeak/blob/main/LICENSE.md) license to default list of allowed licenses.

## Why?

This license is used by [jackspeak](https://www.npmjs.com/package/jackspeak), a library depended upon by the latest version of [glob](https://www.npmjs.com/package/glob) which is used in various of our projects.