### PR TITLE
fix: disable require-typed-object-values-and-entries in js files

### DIFF
--- a/eslint/main.js
+++ b/eslint/main.js
@@ -35,6 +35,7 @@ module.exports = {
 			},
 			rules: {
 				...commonRules,
+				"@sofie-automation/require-typed-object-values-and-entries": "off" // not possible to enforce this in JS
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK

## Type of Contribution

This is a: 
<!-- (pick one) -->
Bug fix 


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

if using `Object.entries()` in a js file, the linting rule will err.


## New Behavior
<!--
What is the new behavior?
-->

no err when using  `Object.entries()` in a js file.



## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
