### PR TITLE
feat: initial support for monorepo with single changelog

### DIFF
--- a/bin/updateVersion.mjs
+++ b/bin/updateVersion.mjs
@@ -110,7 +110,9 @@ const nextVersion = semver.inc(
 	(cli.flags.prerelease !== undefined ? 'pre' : '') + (hasBreaking ? 'major' : hasFeatures ? 'minor' : 'patch'),
 	identifier
 )
-let md = `## [${nextVersion}](${repoUrl}/compare/${lastTag}...v${nextVersion}) (${new Date().toDateString()})\n`
+
+const compareUrl = lastTag ? `${repoUrl}/compare/${lastTag}...v${nextVersion}` : `${repoUrl}/commits/v${nextVersion}`
+let md = `## [${nextVersion}](${compareUrl}) (${new Date().toDateString()})\n`
 
 if (Object.keys(breakingChanges).length) {
 	md += '\n## Breaking changes\n'

--- a/bin/updateVersion.mjs
+++ b/bin/updateVersion.mjs
@@ -38,6 +38,7 @@ const HEADER = `# Changelog\n\nAll notable changes to this project will be docum
 const execPromise = (command) => new Promise((r) => exec(command, (e, out) => (e && r(e)) || r(out)))
 
 const packageFile = JSON.parse(await readFile('./package.json', { encoding: 'utf-8' }))
+const isMonoRepo = !!packageFile.workspaces
 
 if (!packageFile.homepage) {
 	console.error('No repository homepage specified in the package.json, exiting...')
@@ -159,14 +160,23 @@ if (!cli.flags.dryRun) {
 
 	// update the package.json
 	if (existsSync('.yarn')) {
-		// yarn 3 needs a different command
-		await execPromise('yarn version ' + nextVersion)
+		if (isMonoRepo) {
+			// Update all workspaces
+			await execPromise('yarn workspaces foreach --all version -d ' + nextVersion)
+			await execPromise('yarn version apply --all')
+		} else {
+			// yarn 3 needs a different command
+			await execPromise('yarn version ' + nextVersion)
+		}
 	} else {
 		await execPromise('yarn version --no-git-tag-version --new-version ' + nextVersion)
 	}
 
 	// git commit
 	await execPromise(`git add package.json yarn.lock CHANGELOG.md`)
+	if (isMonoRepo) {
+		await execPromise(`git add */package.json`)
+	}
 
 	await execPromise(`git commit -m "chore(release): v${nextVersion}"`)
 


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of NRK.


## Type of Contribution

This is a: Feature

## Current Behavior

If used in a yarn 4 monorepo (without lerna), the versions will not be incremented correctly

## New Behavior

This adds basic support for this situation, updating the versions correctly.

This expects each package to be use identical version numbers, and it only generates a single changelog at the root of the repository


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
