### PR TITLE
fix: typo in changelog header link

### DIFF
--- a/bin/updateVersion.mjs
+++ b/bin/updateVersion.mjs
@@ -35,7 +35,7 @@ const cli = meow(
 )
 
 const START_OF_LAST_RELEASE_PATTERN = /(^#+ \[?[0-9]+\.[0-9]+\.[0-9]+|<a name=)/m
-const HEADER = `# Changelog\n\nAll notable changes to this project will be documented in this file. See [Convential Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) for commit guidelines.\n\n`
+const HEADER = `# Changelog\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) for commit guidelines.\n\n`
 
 const execPromise = (command) =>
 	new Promise((resolve, reject) => exec(command, (e, out) => (e && reject(e)) || resolve(out)))


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core//docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix


## New Behavior

Fix a typo

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixed a typo in the HEADER constant in `bin/updateVersion.mjs` (line 38), changing "Convential Commits" to "Conventional Commits" in the changelog header link.

## Changes

**bin/updateVersion.mjs**
- Line 38: Corrected the text in the HEADER constant from "Convential Commits" to "Conventional Commits"

This fixes the typo that was being written into the CHANGELOG.md file header whenever the version update script runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->