### PR TITLE
fix: replace non-breaking space in .editorconfig; set tabWidth in .prettierrc.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_style = space
 indent_size = 2
 
 [*.{md,diff,patch}]
-# Trailing whitespace is meaningful in these file types
+# Trailing whitespace is meaningful in these file types
 trim_trailing_whitespace = false
 
 [*.md]

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -8,6 +8,7 @@ const config = {
 	semi: false,
 	singleQuote: true,
 	useTabs: true,
+	tabWidth: 4,
 	endOfLine: 'lf',
 	trailingComma: 'es5',
 	plugins: [sortImports],


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of SuperFly.tv.

## Type of Contribution

<!-- (pick one of the below) -->
This is a: Bug fix / Code improvement

## Current Behaviour

- `.editorconfig` had a non-breaking space (U+00A0) character in a comment, which can cause subtle issues in editors that are sensitive to invisible characters.
- `.prettierrc.json` did not set `tabWidth`, so Prettier fell back to reading it from `.editorconfig` when calculating print width — but `.editorconfig` isn't always available (e.g. when the config is resolved from inside `node_modules`).

## New Behaviour

- The non-breaking space in the `.editorconfig` comment is replaced with a regular space.
- `.prettierrc.json` now explicitly sets `"tabWidth": 4`, ensuring consistent line-length calculations regardless of whether `.editorconfig` is present.

## Testing Instructions

- [ ] No unit test changes are needed for this PR

Verify `yarn lint` passes on the repo itself. In a project consuming the preset, verify that Prettier formats with the expected print width (a tab counts as 4 characters towards the 120-character print width limit).

### Affected areas

Affects `.editorconfig` and `.prettierrc.json` in this repo. Consumers of the preset will see a change in how Prettier calculates tab widths for print-width purposes.

## Time Frame

Not urgent.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests have been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
